### PR TITLE
Fix 

### DIFF
--- a/addons/sourcemod/scripting/momsurffix/gametrace.sp
+++ b/addons/sourcemod/scripting/momsurffix/gametrace.sp
@@ -220,19 +220,19 @@ methodmap Ray_t < AllocatableBase
 	property Address m_pWorldAxisTransform
 	{
 		public get() { return view_as<Address>(LoadFromAddress(this.Address + offsets.rtoffsets.m_pWorldAxisTransform, NumberType_Int32)); }
-		public set(Address _worldaxistransform) { StoreToAddress(this.Address + offsets.rtoffsets.m_pWorldAxisTransform, view_as<int>(_worldaxistransform), NumberType_Int32); }
+		public set(Address _worldaxistransform) { StoreToAddressCustom(this.Address + offsets.rtoffsets.m_pWorldAxisTransform, view_as<int>(_worldaxistransform), NumberType_Int32); }
 	}
 	
 	property bool m_IsRay
 	{
 		public get() { return view_as<bool>(LoadFromAddress(this.Address + offsets.rtoffsets.m_IsRay, NumberType_Int8)); }
-		public set(bool _isray) { StoreToAddress(this.Address + offsets.rtoffsets.m_IsRay, _isray, NumberType_Int8); }
+		public set(bool _isray) { StoreToAddressCustom(this.Address + offsets.rtoffsets.m_IsRay, _isray, NumberType_Int8); }
 	}
 	
 	property bool m_IsSwept
 	{
 		public get() { return view_as<bool>(LoadFromAddress(this.Address + offsets.rtoffsets.m_IsSwept, NumberType_Int8)); }
-		public set(bool _isswept) { StoreToAddress(this.Address + offsets.rtoffsets.m_IsSwept, _isswept, NumberType_Int8); }
+		public set(bool _isswept) { StoreToAddressCustom(this.Address + offsets.rtoffsets.m_IsSwept, _isswept, NumberType_Int8); }
 	}
 	
 	public Ray_t()


### PR DESCRIPTION
Basically just replaced the leftover StoreToAddress calls that are used within `ray.Init()` with StoreToAddressCustom.

Performance improvement:
(i had to multiply avg time by 32 because the numbers were too small :) )
Fix:
```
[momsurffix2] Profiler finished:
[momsurffix2] [0] Avg time x32: 0.000003 | Calls: 864
[momsurffix2] [1] Avg time x32: 0.000010 | Calls: 864
[momsurffix2] [2] Avg time x32: 0.000046 | Calls: 864
[momsurffix2] [3] Avg time x32: 0.000042 | Calls: 864
[momsurffix2] [4] Avg time x32: 0.000003 | Calls: 864
```
Previous:
```
[momsurffix2] Profiler finished:
[momsurffix2] [0] Avg time x32: 0.000003 | Calls: 1728
[momsurffix2] [1] Avg time x32: 0.000013 | Calls: 1728
[momsurffix2] [2] Avg time x32: 0.000279 | Calls: 1728
[momsurffix2] [3] Avg time x32: 0.000028 | Calls: 1728
[momsurffix2] [4] Avg time x32: 0.000005 | Calls: 1728
```