### PR TITLE
Fix wrong gamedata offsets

### DIFF
--- a/addons/sourcemod/gamedata/momsurffix2.games.txt
+++ b/addons/sourcemod/gamedata/momsurffix2.games.txt
@@ -35,9 +35,6 @@
 			"CGameTrace::surface"				"60"
 			"CGameTrace::hitgroup"				"68"
 			"CGameTrace::physicsbone"			"72"
-			"CGameTrace::m_pEnt"				"74"
-			"CGameTrace::hitbox"				"80"
-			"CGameTrace::size"					"84"
 			
 			//CTraceFilterSimple
 			"CTraceFilterSimple::vptr"								"0"
@@ -95,6 +92,11 @@
 			"CMoveData::m_vecVelocity"			"64"
 			//...
 			"CMoveData::m_vecAbsOrigin"			"152"
+			
+			//CGameTrace
+			"CGameTrace::m_pEnt"				"74"
+			"CGameTrace::hitbox"				"80"
+			"CGameTrace::size"					"84"
 			
 			//CBaseHandle
 			"CBaseHandle::m_Index"				"0"
@@ -300,6 +302,11 @@
 			"CMoveData::m_vecVelocity"			"64"
 			//...
 			"CMoveData::m_vecAbsOrigin"			"172"
+			
+			//CGameTrace
+			"CGameTrace::m_pEnt"				"76"
+			"CGameTrace::hitbox"				"82"
+			"CGameTrace::size"					"86"
 			
 			//CBasePlayer
 			//Offset is relative to m_ubEFNoInterpParity netprop and will be substracted from it

--- a/addons/sourcemod/scripting/momsurffix/gametrace.sp
+++ b/addons/sourcemod/scripting/momsurffix/gametrace.sp
@@ -75,7 +75,7 @@ methodmap Cplane_t < AddressBase
 	
 	property float dist
 	{
-		public get() { return view_as<float>(LoadFromAddress(this.Address + offsets.cptoffsets.normal, NumberType_Int32)); }
+		public get() { return view_as<float>(LoadFromAddress(this.Address + offsets.cptoffsets.dist, NumberType_Int32)); }
 	}
 	
 	property char type


### PR DESCRIPTION
Some offsets for `CGameTrace` are incorrect for CS:GO, I'm assuming due to the addition of `worldSurfaceIndex`.

https://github.com/ValveSoftware/source-sdk-2013/blob/f56bb35301836e56582a575a75864392a0177875/mp/src/public/gametrace.h#L62

https://github.com/perilouswithadollarsign/cstrike15_src/blob/f82112a2388b841d72cb62ca48ab1846dfcc11c8/public/gametrace.h#L64

Also, there's a typo in `property float dist`.

These are both unused by this plugin, but I figured I'd PR this anyway to avoid potential future confusion.